### PR TITLE
Fix typo in weed tooltip

### DIFF
--- a/src/main/java/net/micaxs/smokeleafindustry/item/custom/BaseWeedItem.java
+++ b/src/main/java/net/micaxs/smokeleafindustry/item/custom/BaseWeedItem.java
@@ -70,7 +70,7 @@ public class BaseWeedItem extends Item {
                 .append(Component.literal("THC: ").withStyle(ChatFormatting.DARK_GRAY))
                 .append(Component.literal(THC_LEVEL + "%").withStyle(ChatFormatting.GREEN))
                 .append(Component.literal(" | ").withStyle(ChatFormatting.GRAY))
-                .append(Component.literal("CDB: ").withStyle(ChatFormatting.DARK_GRAY))
+                .append(Component.literal("CBD: ").withStyle(ChatFormatting.DARK_GRAY))
                 .append(Component.literal(CBD_LEVEL + "%").withStyle(ChatFormatting.GREEN));
     }
 


### PR DESCRIPTION
This fixes the tooltip on weed items showing "CDB" instead of "CBD"